### PR TITLE
fix(*): add error handler

### DIFF
--- a/lib/__test__/backgroundSetup.test.js
+++ b/lib/__test__/backgroundSetup.test.js
@@ -13,6 +13,15 @@ describe("Background Setup", () => {
         setTimeout(() => {
           res("async_test");
         }, 200);
+      }),
+    testError: () => {
+      throw new Error("test_error");
+    },
+    testErrorAsync: () =>
+      new Promise((res, rej) => {
+        setTimeout(() => {
+          rej("async_test_error");
+        }, 200);
       })
   };
 
@@ -40,6 +49,24 @@ describe("Background Setup", () => {
     }
   };
 
+  const req3 = {
+    handler: CHROME_EXT_TOOLKIT,
+    type: INVOKE_FUNCTION,
+    payload: {
+      path: ["testError"],
+      args: []
+    }
+  };
+
+  const req4 = {
+    handler: CHROME_EXT_TOOLKIT,
+    type: INVOKE_FUNCTION,
+    payload: {
+      path: ["testErrorAsync"],
+      args: []
+    }
+  };
+
   it("can create function listeners", done => {
     const sendRes = jest.fn();
     const ret = backgroundSetup.invokeFunction(
@@ -50,10 +77,10 @@ describe("Background Setup", () => {
     );
     expect(ret).toBe(false);
     expect(sendRes.mock.calls.length).toBe(1);
-    expect(sendRes.mock.calls[0][0]).toBe("test");
+    expect(sendRes.mock.calls[0][0]).toEqual({ result: "test" });
 
     const sendRes2 = res => {
-      expect(res).toBe("async_test");
+      expect(res).toEqual({ result: "async_test" });
       done();
     };
     const ret2 = backgroundSetup.invokeFunction(
@@ -64,7 +91,30 @@ describe("Background Setup", () => {
     );
     expect(ret2).toBe(true);
 
+    const sendRes3 = jest.fn();
     const ret3 = backgroundSetup.invokeFunction(
+      req3,
+      sender,
+      sendRes3,
+      bgFuncsMock
+    );
+    expect(ret3).toBe(false);
+    expect(sendRes3.mock.calls.length).toBe(1);
+    expect(sendRes3.mock.calls[0][0]).toEqual({ error: "test_error" });
+
+    const sendRes4 = res => {
+      expect(res).toEqual({ error: "async_test_error" });
+      done();
+    };
+    const ret4 = backgroundSetup.invokeFunction(
+      req4,
+      sender,
+      sendRes4,
+      bgFuncsMock
+    );
+    expect(ret4).toBe(true);
+
+    const ret5 = backgroundSetup.invokeFunction(
       {
         payload: {
           path: ["unknown function"]
@@ -74,7 +124,7 @@ describe("Background Setup", () => {
       () => {},
       bgFuncsMock
     );
-    expect(ret3).toBe(false);
+    expect(ret5).toBe(false);
   });
 
   it("can setup a message listener", () => {
@@ -106,8 +156,12 @@ describe("Background Setup", () => {
     expect(ret).toBe(false);
     expect(sendResMock.mock.calls.length).toBe(1);
     expect(sendResMock.mock.calls[0][0]).toEqual({
-      test: "test",
-      testAsync: "testAsync"
+      result: {
+        test: "test",
+        testAsync: "testAsync",
+        testError: "testError",
+        testErrorAsync: "testErrorAsync"
+      }
     });
 
     ret = handler(req, {}, () => {});

--- a/lib/backgroundSetup.js
+++ b/lib/backgroundSetup.js
@@ -48,7 +48,8 @@ export const invokeFunction = (req, sender, sendRes, bgFuncs) => {
       }
       // If it is a promise (async function) keep the message channel open by returning true and send the reponse after resolving.
       if (typeof ret === "object" && ret.then) {
-        ret.then(result => sendRes({ result })).catch(error => sendRes({ error }));
+        ret.then(result => sendRes({ result }))
+          .catch(error => sendRes({ error: error.message }));
         // Keep the msg channel open for the async response
         return true;
       }

--- a/lib/backgroundSetup.js
+++ b/lib/backgroundSetup.js
@@ -37,18 +37,23 @@ export const invokeFunction = (req, sender, sendRes, bgFuncs) => {
   if (find(bgFuncs, req.payload.path)) {
     let ret = find(bgFuncs, req.payload.path);
     if (typeof ret === "function") {
-      ret = ret(...req.payload.args, {
-        request: req,
-        sender
-      });
+      try {
+        ret = ret(...req.payload.args, {
+          request: req,
+          sender
+        });
+      } catch (error) {
+        sendRes({ error: error.message });
+        return false;
+      }
       // If it is a promise (async function) keep the message channel open by returning true and send the reponse after resolving.
       if (typeof ret === "object" && ret.then) {
-        ret.then(res => sendRes(res));
+        ret.then(result => sendRes({ result })).catch(error => sendRes({ error }));
         // Keep the msg channel open for the async response
         return true;
       }
     }
-    sendRes(ret);
+    sendRes({ result: ret });
     return false;
   }
   return false;
@@ -85,7 +90,9 @@ const setupMessageListener = (bgFuncs = {}, options = {}) => (
   if (req.handler === CHROME_EXT_TOOLKIT) {
     switch (req.type) {
       case GET_FUNCTION_NAMES:
-        sendRes(mapNames(bgFuncs));
+        sendRes({ 
+          result: mapNames(bgFuncs)
+        });
         return false;
       case INVOKE_FUNCTION:
         options.verbose &&

--- a/lib/contentSetup.js
+++ b/lib/contentSetup.js
@@ -10,8 +10,14 @@ import {
  * @returns {Function} sendMessage(msg) -> chrome.runtime.sendMessage
  */
 export const makeSendMessage = chrome => msg =>
-  new Promise(res => {
-    chrome.runtime.sendMessage(msg, response => res(response));
+  new Promise((res, rej) => {
+    chrome.runtime.sendMessage(msg, response => {
+      if (response.error) {
+        rej(response.error);
+      } else {
+        res(response.result);
+      }
+    });
   });
 
 /**


### PR DESCRIPTION
Added the error handler to fix issue #1.

In this PR I created the wrapper around a result which passes to sendRes() function.
The wrapper structure contains two properties:
- `result` is value which is returned by a calling function;
- `error` is string message extracted from an Error object, which throws inside a calling function.

The processing of the wrapper has been added to the makeSendMessage() function of `lib/contentSetup.js`. When the `error` property is not empty, the reject callback of Promise will be called.

I added two unit tests of synchronous and asynchronous functions also which throws errors.